### PR TITLE
black-tufted instead of black tuffed marmoset

### DIFF
--- a/src/assets/animals.json
+++ b/src/assets/animals.json
@@ -15,7 +15,7 @@
     },
     {
         "name": "Momo",
-        "species": "Black Tuffed Marmoset",
+        "species": "Black-tufted Marmoset",
         "img": {
             "src": "animal-images/momo.jpg",
             "altText": "Momo"


### PR DESCRIPTION
I think according to my google searches the common spelling of black-tufted is so. They are also sometimes called black-pencilled marmosets.

See e.g. https://en.wikipedia.org/wiki/Black-tufted_marmoset