### PR TITLE
Sleep/wake overlay based on mouse movement

### DIFF
--- a/src/pages/overlay/App.module.scss
+++ b/src/pages/overlay/App.module.scss
@@ -1,7 +1,7 @@
 .app {
   margin: 90px 15px 15px;
   position: relative;
-  transition: opacity 0.3s;
+  transition: opacity 0.3s ease-out;
 }
 
 .visible {

--- a/src/pages/overlay/App.module.scss
+++ b/src/pages/overlay/App.module.scss
@@ -1,6 +1,15 @@
 .app {
   margin: 90px 15px 15px;
   position: relative;
+  transition: opacity 0.3s;
+}
+
+.visible {
+  opacity: 1;
+}
+
+.hidden {
+  opacity: 0;
 }
 
 @media screen and (max-height: 555px) {

--- a/src/pages/overlay/App.tsx
+++ b/src/pages/overlay/App.tsx
@@ -29,28 +29,40 @@ export default function App(){
         }))
     }, [])
 
-    // Hide the overlay after 5s of no mouse movement
-    const inactiveTimer = useRef<NodeJS.Timeout | undefined>(undefined)
-    const [inactive, setInactive] = useState(false)
-    const onMouseMove = useCallback(() => {
-        setInactive(false)
-        if (inactiveTimer.current) clearTimeout(inactiveTimer.current)
-        inactiveTimer.current = setTimeout(() => {
-            setInactive(true)
-        }, 5000)
+    // Show/hide the overlay based on mouse movement
+    const sleepTimer = useRef<NodeJS.Timeout | undefined>(undefined)
+    const [sleeping, setSleeping] = useState(false)
+    const wake = useCallback((time: number) => {
+        setSleeping(false)
+        if (sleepTimer.current) clearTimeout(sleepTimer.current)
+        sleepTimer.current = setTimeout(() => {
+            setSleeping(true)
+        }, time)
+    }, [])
+    const sleep = useCallback(() => {
+        setSleeping(true)
+        if (sleepTimer.current) clearTimeout(sleepTimer.current)
     }, [])
     useEffect(() => () => {
-        if (inactiveTimer.current) clearTimeout(inactiveTimer.current)
+        if (sleepTimer.current) clearTimeout(sleepTimer.current)
     }, [])
 
     return (
-        <div className={`${styles.app} ${inactive ? styles.hidden : styles.visible}`} onMouseMove={onMouseMove}>
+        <div
+            className={`${styles.app} ${sleeping ? styles.hidden : styles.visible}`}
+            onMouseEnter={() => wake(5000)}
+            onMouseMove={() => wake(5000)}
+            onMouseLeave={sleep}
+        >
             <Overlay
+                sleeping={sleeping}
+                wake={wake}
                 settings={{
                     disableChatPopup: overlaySettings.disableChatPopup
                 }}
             />
             <OverlaySettings
+                sleeping={sleeping}
                 settings={{
                     disableChatPopup: overlaySettings.disableChatPopup
                 }}

--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -28,9 +28,7 @@ export default function Overlay(props: OverlayProps) {
 
     // When a chat command is run, show the list and auto-dismiss it after 6s
     useEffect(() => {
-        if(chosenAmbassador !== undefined && props.settings.disableChatPopup === false){
-            console.log(props.settings.disableChatPopup)
-
+        if (chosenAmbassador !== undefined && !props.settings.disableChatPopup) {
             // Show the list, and dismiss it after 6s
             setShowAmbassadorList(true)
             timeoutRef.current = setTimeout(() => { setShowAmbassadorList(false) }, 6000)
@@ -41,18 +39,17 @@ export default function Overlay(props: OverlayProps) {
             // Wake the overlay for 6s
             props.wake(6000)
         }
-        return () => clearTimeout(timeoutRef.current as NodeJS.Timeout)
 
+        return () => {
+            if (timeoutRef.current) clearTimeout(timeoutRef.current)
+        }
     }, [chosenAmbassador, props.wake])
 
     // If the user interacts with the overlay, clear the auto-dismiss timer
     useEffect(() => {
         const callback = () => {
-            if (awakingRef.current) {
-                awakingRef.current = false
-            } else {
-                clearTimeout(timeoutRef.current as NodeJS.Timeout)
-            }
+            if (awakingRef.current) awakingRef.current = false
+            else if (timeoutRef.current) clearTimeout(timeoutRef.current)
         }
         props.awoken.add(callback)
         return () => props.awoken.remove(callback)

--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -10,56 +10,35 @@ import useChatCommand from '../../../../utils/chatCommand'
 import styles from './overlay.module.css'
 
 interface OverlayProps {
+    sleeping: boolean,
+    wake: (time: number) => void,
     settings: {
         disableChatPopup: boolean
     }
 }
 export default function Overlay(props: OverlayProps) {
     const [showAmbassadorList, setShowAmbassadorList] = useState(false)
-    const [isOverlayVisible, setIsOverlayVisible] = useState(false)
     const chosenAmbassador = useChatCommand()
     const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
 
     useEffect(() => {
         if(chosenAmbassador !== undefined && props.settings.disableChatPopup === false){
             console.log(props.settings.disableChatPopup)
-            setIsOverlayVisible(true)
             setShowAmbassadorList(true)
-
-            // hide overlay after a few seconds
-            timeoutRef.current = setTimeout(() => {
-                setIsOverlayVisible(false)
-                setShowAmbassadorList(false)
-            }, 6000)
+            timeoutRef.current = setTimeout(() => { setShowAmbassadorList(false) }, 6000)
+            props.wake(6000)
         }
-        return () => clearTimeout(timeoutRef.current as NodeJS.Timeout) 
+        return () => clearTimeout(timeoutRef.current as NodeJS.Timeout)
 
-    }, [chosenAmbassador])
+    }, [chosenAmbassador, props.wake])
 
     useEffect(() => {
-        initMouseEventListener()
-    }, [])
-
-    // create mouse event listener to show/hide overlay if mouse is in the viewport
-    const initMouseEventListener = () => {
-        let body = document.querySelector("body")
-        //check if mouse is in the viewport
-        if(body !== null){
-            body.addEventListener('mouseleave', () => {
-                setIsOverlayVisible(false)
-            })
-        }
-        if(body !== null){
-            body.addEventListener('mouseenter', () => {
-                setIsOverlayVisible(true)
-                clearTimeout(timeoutRef.current as NodeJS.Timeout)
-            })
-        }
-    }
+        if (!props.sleeping) clearTimeout(timeoutRef.current as NodeJS.Timeout)
+    }, [props.sleeping])
 
     return (
-    <div className={`${styles.overlay} ${isOverlayVisible? styles.visible : styles.hidden}`} >
-        <ActivationButtons 
+    <div className={`${styles.overlay} ${props.sleeping ? styles.hidden : styles.visible}`} >
+        <ActivationButtons
             toggleShowAmbassadorList={() => setShowAmbassadorList(!showAmbassadorList)}
         />
         <AmbassadorList

--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -11,6 +11,10 @@ import styles from './overlay.module.css'
 
 interface OverlayProps {
     sleeping: boolean,
+    awoken: {
+        add: (callback: () => void) => void,
+        remove: (callback: () => void) => void
+    }
     wake: (time: number) => void,
     settings: {
         disableChatPopup: boolean
@@ -20,21 +24,39 @@ export default function Overlay(props: OverlayProps) {
     const [showAmbassadorList, setShowAmbassadorList] = useState(false)
     const chosenAmbassador = useChatCommand()
     const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
+    const awakingRef = useRef(false)
 
+    // When a chat command is run, show the list and auto-dismiss it after 6s
     useEffect(() => {
         if(chosenAmbassador !== undefined && props.settings.disableChatPopup === false){
             console.log(props.settings.disableChatPopup)
+
+            // Show the list, and dismiss it after 6s
             setShowAmbassadorList(true)
             timeoutRef.current = setTimeout(() => { setShowAmbassadorList(false) }, 6000)
+
+            // Track that we're waking up, so that we don't immediately clear the timeout
+            awakingRef.current = true
+
+            // Wake the overlay for 6s
             props.wake(6000)
         }
         return () => clearTimeout(timeoutRef.current as NodeJS.Timeout)
 
     }, [chosenAmbassador, props.wake])
 
+    // If the user interacts with the overlay, clear the auto-dismiss timer
     useEffect(() => {
-        if (!props.sleeping) clearTimeout(timeoutRef.current as NodeJS.Timeout)
-    }, [props.sleeping])
+        const callback = () => {
+            if (awakingRef.current) {
+                awakingRef.current = false
+            } else {
+                clearTimeout(timeoutRef.current as NodeJS.Timeout)
+            }
+        }
+        props.awoken.add(callback)
+        return () => props.awoken.remove(callback)
+    }, [props.awoken])
 
     return (
     <div className={`${styles.overlay} ${props.sleeping ? styles.hidden : styles.visible}`} >

--- a/src/pages/overlay/components/overlay/overlay.module.scss
+++ b/src/pages/overlay/components/overlay/overlay.module.scss
@@ -3,17 +3,16 @@
 .overlay {
     display: flex;
     gap: 10px;
-    transition: 0.3s;
+    transition: 0.3s ease-out;
+    transition-property: visibility, translate;
 }
 
 .visible {
     visibility: visible;
-    opacity: 1;
 }
 
 .hidden {
     visibility: hidden;
-    opacity: 0;
     translate: -40px;
 }
 
@@ -45,13 +44,8 @@
 }
 
 @media (prefers-reduced-motion) {
-    // disolve in and out
-    .visible {
-        opacity: 1;
-    }
-
+    // just rely on app fade
     .hidden {
-        opacity: 0;
         translate: 0;
     }
 }

--- a/src/pages/overlay/components/overlaySettings/OverlaySettings.tsx
+++ b/src/pages/overlay/components/overlaySettings/OverlaySettings.tsx
@@ -1,6 +1,3 @@
-//utils
-import { useEffect, useState } from "react"
-
 //components
 import DisableChatPopup from "../disableChatPopup/DisableChatPopup"
 
@@ -8,39 +5,19 @@ import DisableChatPopup from "../disableChatPopup/DisableChatPopup"
 import styles from "./overlaySettings.module.css"
 
 interface OverlaySettingsProps {
+    sleeping: boolean,
     settings: {
         disableChatPopup: boolean
     }
     toggleDisableChatPopup: () => void
 }
 export default function OverlaySettings(props: OverlaySettingsProps){
-    const [isOverlaySettingsVisible, setIsOverlaySettingsVisible] = useState(false)
-
-    useEffect(() => {
-        initMouseEventListener()
-    }, [])
-
     const toggleDisableChatPopup = () => {
         props.toggleDisableChatPopup()
     }
 
-    // create mouse event listener to show/hide overlay if mouse is in the viewport
-    const initMouseEventListener = () => {
-        let body = document.querySelector("body")
-        //check if mouse is in the viewport
-        if(body !== null){
-            body.addEventListener('mouseleave', () => {
-                setIsOverlaySettingsVisible(false)
-            })
-        }
-        if(body !== null){
-            body.addEventListener('mouseenter', () => {
-                setIsOverlaySettingsVisible(true)
-            })
-        }
-    }
     return (
-        <div className={`${styles.overlaySettings} ${isOverlaySettingsVisible ? styles.visible : styles.hidden}`}>
+        <div className={`${styles.overlaySettings} ${props.sleeping ? styles.hidden : styles.visible}`}>
             <DisableChatPopup
                 disableChatPopup={props.settings.disableChatPopup}
                 toggleDisableChatPopup={()=>toggleDisableChatPopup()}

--- a/src/pages/overlay/components/overlaySettings/overlaySettings.module.scss
+++ b/src/pages/overlay/components/overlaySettings/overlaySettings.module.scss
@@ -2,28 +2,22 @@
     position: absolute;
     top: 40px; // Matching the margin-top of the activation buttons
     right: 0;
-    transition: all 0.15s ease-out;
+    transition: 0.3s ease-out;
+    transition-property: visibility, translate;
 }
 
 .visible {
     visibility: visible;
-    opacity: 1;
 }
 
 .hidden {
     visibility: hidden;
-    opacity: 0;
     translate: 40px;
 }
 
 @media (prefers-reduced-motion) {
-    //disolve in and out
-    .visible {
-        opacity: 1;
-    }
-
+    // just rely on app fade
     .hidden {
-        opacity: 0;
         translate: 0;
     }
 }


### PR DESCRIPTION
Resolves #16 

This adds a 5s timeout for mouse movement before the overlay will hide itself.

This also centralizes the visibility logic that was duplicated across overlay + overlaysettings, both hooking into the same visibility control that the mouse movement timeout uses.