### PR TITLE
Improve overlay scaling

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,4 @@
-//Global styles
+// Global styles
 @import './variables.scss';
 
 * {
@@ -6,9 +6,18 @@
   padding: 0;
 }
 
+// change default box-sizing mode to border-box
+// meaning total width/height includes padding and border
+*,
+::before,
+::after {
+  box-sizing: border-box;
+}
+
 body {
   font-family: $font-family;
   color: $primary-text;
+
   display: flex;
   justify-content: center;
   overflow-x: hidden; // no horizontal scrollbar

--- a/src/pages/overlay/App.module.scss
+++ b/src/pages/overlay/App.module.scss
@@ -1,29 +1,8 @@
 .app {
-  margin: 90px 15px 15px;
-  position: relative;
-  transition: opacity 0.3s ease-out;
-}
-
-.visible {
-  opacity: 1;
-}
-
-.hidden {
-  opacity: 0;
-
-  * {
-    pointer-events: none;
-  }
-}
-
-@media screen and (max-height: 555px) {
-  .app {
-    margin-top: 40px;
-  }
-}
-
-@media screen and (max-height: 440px) {
-  .app {
-    margin-top: 20px;
-  }
+  // keep space for twitch player ui above and below the extension
+  position: absolute;
+  top: 95px;
+  bottom: 40px;
+  left: 15px;
+  right: 15px;
 }

--- a/src/pages/overlay/components/activationButtons/activationButtons.module.scss
+++ b/src/pages/overlay/components/activationButtons/activationButtons.module.scss
@@ -1,19 +1,32 @@
 @import '../../../../variables.scss';
 
 .activationButtons {
-  margin-top: 40px;
+  margin-top: calc(6 * $overlay-base-size); // move slightly lower relative to available height
 
   button {
     all: unset;
+    display: flex;
+    justify-content: center;
+
+    // scale based on available height
+    width: calc(6.5 * $overlay-base-size);
+    height: calc(6.5 * $overlay-base-size);
+
     border-radius: 5px;
     background-color: $primary-color;
     box-shadow: 0 2px 4px $accent-color;
 
-    padding: 5px;
-
     img {
-      width: 55px;
-      height: 55px;
+      width: 80%;
+      height: auto;
+      aspect-ratio: 1;
+      object-fit: contain;
+
+      // the logo is not visually centered in the image
+      // so we tweak the position a bit to look centered
+      position: relative;
+      left: -2%;
+      top: -1%;
     }
 
     &:hover {

--- a/src/pages/overlay/components/ambassadorList/AmbassadorList.tsx
+++ b/src/pages/overlay/components/ambassadorList/AmbassadorList.tsx
@@ -1,5 +1,5 @@
 //utils
-import { useState, useRef, useEffect } from 'react'
+import {useState, useRef, useEffect} from 'react'
 import {AmbassadorCardProps} from '../../../../utils/global/ambassadorCard/AmbassadorCard'
 import AmbassadorData from '../../../../assets/ambassadors.json'
 
@@ -20,11 +20,11 @@ export default function AmbassadorList(props: AmbassadorListProps) {
   const [ambassadors] = useState(AmbassadorData)
   const [activeAmbassador, setActiveAmbassador] = useState<AmbassadorCardProps["cardData"] | null>()
 
-  const upArrowRef = useRef<HTMLImageElement>(null)
+  const upArrowRef = useRef<HTMLButtonElement>(null)
   const ambassadorList = useRef<HTMLDivElement>(null)
-  const downArrowRef = useRef<HTMLImageElement>(null)
+  const downArrowRef = useRef<HTMLButtonElement>(null)
 
-  useEffect(() =>{ // show the card of the ambassador that Twitch chat chose
+  useEffect(() => { // show the card of the ambassador that Twitch chat chose
     if (props.chatChosenAmbassador !== undefined) {
       const ambassador = ambassadors.find(ambassador => ambassador.name.split(" ")[0].toLowerCase() === props.chatChosenAmbassador)
       if (ambassador) {
@@ -61,9 +61,12 @@ export default function AmbassadorList(props: AmbassadorListProps) {
 
   return (
     <div className={styles.ambassadorList}>
-      <div className={`${styles.scrollAmbassadors} ${props.showAmbassadorList? styles.visible : styles.hidden}`}>
-        <img ref={upArrowRef} src={arrow} className={`${styles.arrow} ${styles.up} ${styles.hideArrow}`} onClick={()=>ambassadorListScroll(250)} alt="Up Arrow"/>
-        <div ref={ambassadorList} className={styles.ambassadors} onScroll={()=>handleArrowVisibility()}>
+      <div className={`${styles.scrollAmbassadors} ${props.showAmbassadorList ? styles.visible : styles.hidden}`}>
+        <button ref={upArrowRef} className={`${styles.arrow} ${styles.up} ${styles.hideArrow}`}
+                onClick={() => ambassadorListScroll(250)}>
+          <img src={arrow} alt="Up Arrow"/>
+        </button>
+        <div ref={ambassadorList} className={styles.ambassadors} onScroll={() => handleArrowVisibility()}>
           {ambassadors && ambassadors.map(ambassador => (
             <AmbassadorButton
               key={ambassador.name}
@@ -74,24 +77,31 @@ export default function AmbassadorList(props: AmbassadorListProps) {
                 altText: ambassador.img.altText
               }}
 
-              getCard={() => {setActiveAmbassador(activeAmbassador?.name === ambassador.name ? undefined : ambassador)}}
+              getCard={() => {
+                setActiveAmbassador(activeAmbassador?.name === ambassador.name ? undefined : ambassador)
+              }}
 
               ClassName={`${styles.ambassadorButton} ${activeAmbassador?.name === ambassador.name ? styles.ambassadorButtonClicked : undefined}`}
               Id={ambassador.name.split(" ")[0].toLowerCase()}
             />
           ))}
         </div>
-        <img ref={downArrowRef} src={arrow} className={`${styles.arrow} ${styles.down}`} onClick={()=>ambassadorListScroll(-250)} alt="Down Arrow"/>
+        <button ref={downArrowRef} className={`${styles.arrow} ${styles.down}`}
+                onClick={() => ambassadorListScroll(-250)}>
+          <img src={arrow} alt="Down Arrow"/>
+        </button>
       </div>
 
-      {activeAmbassador && props.showAmbassadorList ? (
+      {activeAmbassador && props.showAmbassadorList ?
         <AmbassadorCard
           key={activeAmbassador.name}
           cardData={activeAmbassador}
-          close={() => {setActiveAmbassador(undefined)}}
+          close={() => {
+            setActiveAmbassador(undefined)
+          }}
           ClassName={styles.ambassadorCard}
-        />
-      ) : null}
+        /> : null
+      }
     </div>
   )
 }

--- a/src/pages/overlay/components/ambassadorList/ambassadorList.module.scss
+++ b/src/pages/overlay/components/ambassadorList/ambassadorList.module.scss
@@ -1,44 +1,78 @@
+@import '../../../../variables.scss';
+
 .ambassadorList {
   display: flex;
+  font-size: calc(1.6 * $overlay-base-size); // dynamic font size based on available height
 
   .scrollAmbassadors {
     display: flex;
     flex-direction: column;
     align-items: center;
-    gap: 10px;
-    transition: 0.3s;
-    z-index: 1;
+    position: relative; // to position arrows absolutely on top of the items
+    z-index: 1; // stay above the popup card
+    transition: 300ms;
 
     .ambassadors {
-      overflow: scroll;
-      height: 70vh;
-      scrollbar-width: none;//remove scrollbar
-
       display: flex;
+      // scale ambassadors based on available height
+      width: calc(15 * $overlay-base-size);
+      padding: calc(3 * $overlay-base-size) $overlay-base-size;
+      gap: calc(2 * $overlay-base-size);
+
       flex-direction: column;
       align-items: center;
-      padding: 10px;
 
-      & > * {
-        margin-bottom: 20px;
-      }
+      overflow: scroll;
 
+      // mask image to fade out the list to transparent top and bottom
+      // using a gradient as image of which the alpha channel will be
+      // applied to the content of the list
+      //  0% -   3% gradient from 0% to 100% alpha
+      //  3% -  97% 100% alpha
+      // 97% - 100% gradient from 100% to 0% alpha
+      mask-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 0%, rgba(0, 0, 0, 1) 3%, rgba(0, 0, 0, 1) 97%, rgba(0, 0, 0, 0) 100%);
+
+      scrollbar-width: none; // remove scrollbar (supported in Firefox)
       &::-webkit-scrollbar {
-        display: none;
+        display: none; // remove scrollbar (supported in Chrome, Safari, Edge etc.)
       }
     }
 
     .arrow {
-      width: 30px;
-      transition: 0.3s;
+      // position the arrow on top the list
+      position: absolute;
+      border: 0;
+
+      // keeping a fixed size here so the click target is big enough
+      width: 40px;
+      height: 40px;
+      padding: 10px;
+
+      border-radius: 20px;
+      background-clip: content-box;
+      background: rgb(0 0 0 / 30%);
+      backdrop-filter: blur(5px);
+      z-index: 10000;
+
+      img {
+        width: 100%;
+        height: auto;
+      }
 
       &:hover {
         scale: 1.4;
         cursor: pointer;
       }
+
+      transition: 0.3s;
+    }
+
+    .up {
+      top: 0;
     }
 
     .down {
+      bottom: 0;
       transform: rotate(180deg);
     }
   }
@@ -52,6 +86,12 @@
     visibility: hidden;
     opacity: 0;
     translate: -40px;
+
+    // accessibility for vestibular motion disorders
+    // do not translate list (but keep opacity transition)
+    @media (prefers-reduced-motion) {
+      translate: 0;
+    }
   }
 
   .ambassadorButton {
@@ -69,8 +109,31 @@
 
   .ambassadorCard {
     align-self: center;
+    z-index: 0; // stay below ambassadors list
+
+    // we scale the fixed size card based on the available height so it
+    // stays completely visible and within the clickable overlay area:
+    transform-origin: center left;
+    @media screen and (max-height: 555px) {
+      scale: 0.9;
+    }
+    @media screen and (max-height: 500px) {
+      scale: 0.8;
+    }
+    @media screen and (max-height: 450px) {
+      scale: 0.7;
+    }
+    @media screen and (max-height: 410px) {
+      scale: 0.6;
+    }
+
+    // slide in the card when it gets visible
     animation: slideIn 0.5s ease-in-out;
-    z-index: 0;
+    // accessibility for vestibular motion disorders
+    // do not translate card but only animate opacity
+    @media (prefers-reduced-motion) {
+      animation: dissolveIn 0.5s ease-in-out;
+    }
   }
 
   .hideArrow {
@@ -91,7 +154,8 @@
   }
 }
 
-// accessibility for vestibular motion disorders
+// alternative simple opacity animation
+// (accessibility for vestibular motion disorders)
 @keyframes dissolveIn {
   0% {
     opacity: 0;
@@ -99,23 +163,5 @@
 
   100% {
     opacity: 1;
-  }
-}
-
-@media (prefers-reduced-motion) {
-  .ambassadorList {
-    .ambassadorCard {
-      animation: dissolveIn 0.5s ease-in-out;
-      -webkit-animation: dissolveIn 0.5s ease-in-out;
-    }
-
-    .visible {
-      opacity: 1;
-    }
-
-    .hidden {
-      opacity: 0;
-      translate: 0;
-    }
   }
 }

--- a/src/pages/overlay/components/overlay/overlay.module.scss
+++ b/src/pages/overlay/components/overlay/overlay.module.scss
@@ -2,50 +2,28 @@
 
 .overlay {
   display: flex;
-  gap: 10px;
-  transition: 0.3s ease-out;
-  transition-property: visibility, translate;
+  height: 100%;
+  width: 100%;
+
+  // horizontal spacing (scaled dynamically based on available height)
+  gap: $overlay-base-size;
+
+  transition: all 0.3s ease-out;
 }
 
 .visible {
   visibility: visible;
+  opacity: 1;
 }
 
 .hidden {
   visibility: hidden;
+  opacity: 0;
   translate: -40px;
-}
 
-//media query min height 545px
-@media screen and (max-height: 555px) {
-  .overlay {
-    // scale down the overlay
-    scale: 0.8;
-    // move the overlay up
-    transform: translateX(-12%);
-
-    .scrollAmbassadors .ambassadorList {
-      height: 80vh;
-    }
-  }
-}
-
-@media screen and (max-height: 440px) {
-  .overlay {
-    // scale down the overlay
-    scale: 0.6;
-    // move the overlay up
-    transform: translateX(-32%);
-
-    .scrollAmbassadors .ambassadorList {
-      height: 90vh;
-    }
-  }
-}
-
-@media (prefers-reduced-motion) {
-  // just rely on app fade
-  .hidden {
+  // accessibility for vestibular motion disorders
+  // do not translate overlay but only transition opacity
+  @media (prefers-reduced-motion) {
     translate: 0;
   }
 }

--- a/src/pages/overlay/components/overlaySettings/overlaySettings.module.scss
+++ b/src/pages/overlay/components/overlaySettings/overlaySettings.module.scss
@@ -1,6 +1,8 @@
+@import '../../../../variables.scss';
+
 .overlaySettings {
   position: absolute;
-  top: 40px; // Matching the margin-top of the activation buttons
+  top: calc(6 * $overlay-base-size); // Matching the margin-top of the activation buttons
   right: 0;
   transition: 0.3s ease-out;
   transition-property: visibility, translate;

--- a/src/pages/overlay/index.scss
+++ b/src/pages/overlay/index.scss
@@ -5,6 +5,19 @@
   padding: 0;
 }
 
+// change default box-sizing mode to border-box
+// meaning total width/height includes padding and border
+*,
+::before,
+::after {
+  box-sizing: border-box;
+}
+
 body {
   font-family: $font-family;
+
+  // always keep full width/height and never show scrollbars
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
 }

--- a/src/pages/panel/components/ambassadorPanel/AmbassadorPanel.tsx
+++ b/src/pages/panel/components/ambassadorPanel/AmbassadorPanel.tsx
@@ -46,6 +46,7 @@ export default function AmbassadorPanel() {
               src: ambassador.img.src,
               altText: ambassador.img.altText
             }}
+            ClassName={styles.item}
 
             getCard={()=>handleGetCard(ambassador.name)}
           />

--- a/src/pages/panel/components/ambassadorPanel/ambassadorPanel.module.scss
+++ b/src/pages/panel/components/ambassadorPanel/ambassadorPanel.module.scss
@@ -3,5 +3,10 @@
   flex-wrap: wrap;
   gap: 20px;
   justify-content: center;
+
   padding: 15px;
+}
+
+.item {
+  width: 120px; //using a fixed size here to scale the dynamic ambassador
 }

--- a/src/pages/panel/components/nav/nav.module.scss
+++ b/src/pages/panel/components/nav/nav.module.scss
@@ -4,12 +4,14 @@
   display: flex;
   justify-content: center;
   align-items: center;
+
   background-color: $primary-color;
   box-shadow: 0 3px 4px #2c2c2c;
+
   padding: 10px;
 
   img {
-    width: 30px;
+    width: auto;
     height: 30px;
     margin-right: 10px;
   }

--- a/src/utils/compositions/ambassador/ambassador.module.scss
+++ b/src/utils/compositions/ambassador/ambassador.module.scss
@@ -4,8 +4,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  padding: 20px 15px;
+  padding: 1.1em 0.9em;
   background-color: $primary-color;
   border-radius: 10px;
   text-align: center;

--- a/src/utils/global/ambassadorButton/ambassadorButton.module.scss
+++ b/src/utils/global/ambassadorButton/ambassadorButton.module.scss
@@ -1,8 +1,13 @@
 @import '../../../variables.scss';
 
 .ambassador {
-  width: 100px;
-  height: 100px;
+  // assume the width provided from the parent so
+  // we use the same class in both overlay (dynamic size)
+  // and panel (fixed size)
+  width: 100%;
+
+  aspect-ratio: 1;
+  flex-shrink: 0;
   box-shadow: 0 4px 5px $accent-color;
 
   &:hover {
@@ -11,20 +16,24 @@
   }
 
   .img {
+    margin-bottom: 5px;
     border-radius: 5px;
-    height: 70px;
-    max-width: 100px;
+    flex-shrink: 0; // prevent long names/species to shrink the image height
+    // crop image to 2.2:1:
+    width: 100%;
+    aspect-ratio: 2.2;
     object-fit: cover;
     margin-bottom: 5px;
   }
 
   .name {
     color: $primary-text;
-    font-size: 0.8rem;
+    font-size: 0.8em; // using em so we can scale with the parent
   }
 
   .species {
-    font-size: 0.7rem;
+    font-size: 0.7em; // using em so we can scale with the parent
     color: $secondary-text;
+    line-height: 1.2; // slightly reduce line height if species is multi-line
   }
 }

--- a/src/utils/global/ambassadorCard/ambassadorCard.module.scss
+++ b/src/utils/global/ambassadorCard/ambassadorCard.module.scss
@@ -1,19 +1,20 @@
 @import '../../../variables.scss';
 
 .ambassadorCard {
-  width: 275px;
-  height: 425px;
+  width: 295px;
+  height: 460px;
   justify-content: start;
   align-items: baseline;
   background-color: $accent-color;
   border: 10px solid $primary-color;
   border-radius: 20px;
   box-shadow: 0 3px 3px $accent-color;
-  padding: 5px 0;
-  padding-bottom: 10px;
+  padding: 5px 0 10px 0;
+
   color: $primary-text;
   text-align: left;
   font-size: 0.7rem;
+
   position: relative;
 
   h3 {
@@ -28,7 +29,7 @@
     font-size: x-large;
     cursor: pointer;
 
-    &:hover{
+    &:hover {
       filter: brightness(0.7);
     }
   }
@@ -36,7 +37,9 @@
   .img {
     //crop image with a ratio of 2.2:1
     width: 100%;
-    height: 125px;
+    aspect-ratio: 2.2;
+    object-fit: cover;
+
     align-self: center;
     border-radius: 0;
     margin-bottom: 5px;
@@ -59,7 +62,7 @@
 
   .story,
   .conservationmission {
-    height: 60px;
+    height: 65px;
     padding-bottom: 5px;
   }
 

--- a/src/variables.scss
+++ b/src/variables.scss
@@ -9,3 +9,15 @@ $primary-text: white;
 $secondary-text: #dcdcdc;
 
 $font-family: 'Nunito', sans-serif;
+
+// used to scale various elements based on available height
+// but clamped between 6px and 10px to prevent tiny/giant UI
+// the values are chosen so that in a normal desktop resolution
+// 1 base unit === 10px to make the math easier when using it
+// to scale elements.
+//
+// usage example:
+//   width: calc(5 * $overlay-base-size);
+//   => which would be 50px in normal views and
+//        would scale down to 30px
+$overlay-base-size: clamp(6px, 1.46vh, 10px);


### PR DESCRIPTION
My first attempt on the improved scaling.

- Instead of scaling everything with `scale()` i opted to scale the list components separately with some `calc(x * clamp())` math to keep the scaling within bounds. With that we can make the list always use the full height of the overlay container which i have positioned to keep the recommended 5rem (=50px) space above and below.
- I moved the arrows above the list. I am not sure if you actually wanted that
- I added a `mask-image` to fade out the ambassador list
- I kept the previous scaling method for the card (using scale transforms) but added some more steps

Resolves #24 