### PR TITLE
Tweaked design for disable popup toggle

### DIFF
--- a/src/pages/overlay/App.module.scss
+++ b/src/pages/overlay/App.module.scss
@@ -1,0 +1,16 @@
+.app {
+  margin: 90px 15px 15px;
+  position: relative;
+}
+
+@media screen and (max-height: 555px) {
+  .app {
+    margin-top: 40px;
+  }
+}
+
+@media screen and (max-height: 440px) {
+  .app {
+    margin-top: 20px;
+  }
+}

--- a/src/pages/overlay/App.tsx
+++ b/src/pages/overlay/App.tsx
@@ -6,14 +6,15 @@ import Overlay from "./components/overlay/Overlay"
 import OverlaySettings from "./components/overlaySettings/OverlaySettings"
 
 // css
-import "./App.css"
+import styles from "./App.module.css"
+
 export default function App(){
     const [overlaySettings, setOverlaySettings] = useState({
         disableChatPopup: false,
     })
 
     useEffect(() => {
-        //load settings from local storage 
+        //load settings from local storage
         setOverlaySettings(JSON.parse(localStorage.getItem("settings") || "{}"))
     }, [])
     useEffect(() => {
@@ -29,18 +30,18 @@ export default function App(){
     }
 
     return (
-        <div className="App">
+        <div className={styles.app}>
             <Overlay
                 settings={{
-                    disableChatPopup: overlaySettings.disableChatPopup 
+                    disableChatPopup: overlaySettings.disableChatPopup
                 }}
             />
-            <OverlaySettings 
+            <OverlaySettings
                 settings={{
                     disableChatPopup: overlaySettings.disableChatPopup
                 }}
                 toggleDisableChatPopup={()=>toggleDisableChatPopup()}
-            /> 
+            />
         </div>
     )
 }

--- a/src/pages/overlay/components/disableChatPopup/DisableChatPopup.tsx
+++ b/src/pages/overlay/components/disableChatPopup/DisableChatPopup.tsx
@@ -6,15 +6,11 @@ interface DisableChatPopupProps {
     toggleDisableChatPopup: () => void
 }
 export default function DisableChatPopup(props: DisableChatPopupProps){
-    const toggleDisableChatPopup = () => {
-        props.toggleDisableChatPopup()
-    }
-
     return (
         <div className={styles.switchContainer}>
-            <label>{props.disableChatPopup ? "Enable" : "Disable"} Popups</label>
+            <label>Popups {props.disableChatPopup ? "disabled" : "enabled"}</label>
             <label className={styles.switch}>
-                <input type="checkbox" onClick={()=>toggleDisableChatPopup()} defaultChecked={props.disableChatPopup} />
+                <input type="checkbox" onChange={props.toggleDisableChatPopup} checked={!props.disableChatPopup} />
                 <span className={`${styles.slider} ${styles.round}`} ></span>
             </label>
         </div>

--- a/src/pages/overlay/components/disableChatPopup/DisableChatPopup.tsx
+++ b/src/pages/overlay/components/disableChatPopup/DisableChatPopup.tsx
@@ -11,7 +11,7 @@ export default function DisableChatPopup(props: DisableChatPopupProps){
             <label>Popups {props.disableChatPopup ? "disabled" : "enabled"}</label>
             <label className={styles.switch}>
                 <input type="checkbox" onChange={props.toggleDisableChatPopup} checked={!props.disableChatPopup} />
-                <span className={`${styles.slider} ${styles.round}`} ></span>
+                <span className={styles.slider}></span>
             </label>
         </div>
     )

--- a/src/pages/overlay/components/disableChatPopup/disableChatPopup.module.scss
+++ b/src/pages/overlay/components/disableChatPopup/disableChatPopup.module.scss
@@ -9,28 +9,40 @@
     border-radius: 5px;
     text-align: center;
     padding: 2px;
-    height: 80px;
-    width: 40px;
+    width: 60px;
     color: white;
     font-size: x-small;
 
-    /* The switch - the box around the slider */
+    // The switch - the box around the slider
     .switch {
         position: relative;
         display: inline-block;
-        width: 23px;
-        height: 40px;
+        width: 40px;
+        height: 23px;
         margin-top: 5px;
+
+        input {
+            // Hide default HTML checkbox
+            opacity: 0;
+            width: 0;
+            height: 0;
+
+            &:focus + .slider {
+                box-shadow: 0 0 1px #2196f3;
+            }
+
+            // Show the active state
+            &:checked + .slider {
+                background-color: $primary-color;
+
+                &::before {
+                    transform: translateX(15px);
+                }
+            }
+        }
     }
 
-    /* Hide default HTML checkbox */
-    .switch input {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-
-    /* The slider */
+    // The slider itself
     .slider {
         position: absolute;
         cursor: pointer;
@@ -39,45 +51,26 @@
         right: 0;
         bottom: 0;
         border: 1px solid black;
-        background-color: white;
-    }
-
-    .slider:before {
-        position: absolute;
-        content: "";
-        height: 17px;
-        width: 17px;
-        left: 2px;
-        top: 3px;
-        -webkit-transition: 0.4s;
-        transition: 0.4s;
-    }
-
-    input:focus + .slider {
-        box-shadow: 0 0 1px #2196f3;
-    }
-
-    input:checked + .slider:before {
-        -webkit-transform: translateY(15px);
-        -ms-transform: translateY(15px);
-        transform: translateY(15px);
-    }
-    /* Rounded sliders */
-    .slider.round {
         border-radius: 34px;
-    }
+        background-color: $tertiary-color;
 
-    .slider.round:before {
-        background-color: $primary-color;
-        border-radius: 50%;
+        // The knob inside the slider
+        &::before {
+            position: absolute;
+            content: "";
+            height: 17px;
+            width: 17px;
+            left: 3px;
+            top: 2px;
+            border-radius: 50%;
+            background-color: white;
+            transition: transform 0.4s;
+        }
     }
 }
+
 @media (prefers-reduced-motion) {
     .slider:before {
-        -webkit-transition: none;
         transition: none;
-        -moz-transition: none;
-        -ms-transition: none;
-        -o-transition: none;
     }
 }

--- a/src/pages/overlay/components/disableChatPopup/disableChatPopup.module.scss
+++ b/src/pages/overlay/components/disableChatPopup/disableChatPopup.module.scss
@@ -8,8 +8,9 @@
     background-color: #18181b;
     border-radius: 5px;
     text-align: center;
-    padding: 2px;
+    padding: 10px;
     width: 60px;
+    box-sizing: border-box;
     color: white;
     font-size: x-small;
 

--- a/src/pages/overlay/components/overlay/overlay.module.scss
+++ b/src/pages/overlay/components/overlay/overlay.module.scss
@@ -1,17 +1,17 @@
 @import '../../../../variables.scss';
 
-.overlay{
+.overlay {
     display: flex;
-    padding: 20px;
-    padding-top: 90px;
     gap: 10px;
     transition: 0.3s;
 }
-.visible{
+
+.visible {
     visibility: visible;
     opacity: 1;
 }
-.hidden{
+
+.hidden {
     visibility: hidden;
     opacity: 0;
     translate: -40px;
@@ -19,37 +19,39 @@
 
 //media query min height 545px
 @media screen and (max-height: 555px) {
-    .overlay{
-        //scale down the overlay
-        scale: 0.8 ;
-        //move the overlay up
+    .overlay {
+        // scale down the overlay
+        scale: 0.8;
+        // move the overlay up
         transform: translateX(-12%);
-        padding-top: 40px;
-        .scrollAmbassadors .ambassadorList{
+
+        .scrollAmbassadors .ambassadorList {
             height: 80vh;
         }
     }
 }
+
 @media screen and (max-height: 440px) {
-    .overlay{
-        //scale down the overlay
-        scale: 0.6 ;
-        //move the overlay up
+    .overlay {
+        // scale down the overlay
+        scale: 0.6;
+        // move the overlay up
         transform: translateX(-32%);
-        padding-top: 20px;
-        .scrollAmbassadors .ambassadorList{
+
+        .scrollAmbassadors .ambassadorList {
             height: 90vh;
         }
     }
 }
 
 @media (prefers-reduced-motion) {
-    //disolve in and out
-    .visible{
+    // disolve in and out
+    .visible {
         opacity: 1;
     }
-    .hidden{
+
+    .hidden {
         opacity: 0;
         translate: 0;
-    } 
+    }
 }

--- a/src/pages/overlay/components/overlaySettings/overlaySettings.module.scss
+++ b/src/pages/overlay/components/overlaySettings/overlaySettings.module.scss
@@ -1,7 +1,7 @@
 .overlaySettings {
     position: absolute;
-    top: 130px; // Match the position of the overlay button
-    right: 20px;
+    top: 40px; // Matching the margin-top of the activation buttons
+    right: 0;
     transition: all 0.15s ease-out;
 }
 
@@ -25,17 +25,5 @@
     .hidden {
         opacity: 0;
         translate: 0;
-    }
-}
-
-@media screen and (max-height: 555px) {
-    .overlaySettings {
-        top: 80px;
-    }
-}
-
-@media screen and (max-height: 440px) {
-    .overlaySettings {
-        top: 60px;
     }
 }

--- a/src/pages/overlay/components/overlaySettings/overlaySettings.module.scss
+++ b/src/pages/overlay/components/overlaySettings/overlaySettings.module.scss
@@ -1,26 +1,41 @@
-.overlaySettings{
+.overlaySettings {
     position: absolute;
-    bottom: 65%;
-    right: 25px;
-
+    top: 130px; // Match the position of the overlay button
+    right: 20px;
     transition: all 0.15s ease-out;
 }
-.visible{
+
+.visible {
     visibility: visible;
     opacity: 1;
 }
-.hidden{
+
+.hidden {
     visibility: hidden;
     opacity: 0;
     translate: 40px;
 }
+
 @media (prefers-reduced-motion) {
     //disolve in and out
-    .visible{
+    .visible {
         opacity: 1;
     }
-    .hidden{
+
+    .hidden {
         opacity: 0;
         translate: 0;
-    } 
+    }
+}
+
+@media screen and (max-height: 555px) {
+    .overlaySettings {
+        top: 80px;
+    }
+}
+
+@media screen and (max-height: 440px) {
+    .overlaySettings {
+        top: 60px;
+    }
 }


### PR DESCRIPTION
👋 I made a couple of design tweaks to the disable popups toggle that I think will make it visually easier to understand, aligning it more with standard UI components found across the web etc.

This changes the wording to show the current state, rather than what the toggle would do by changing it, which I think provides more definitive language.

I've also added color to the toggle, to help aid with visually understanding if it is enabled or not -- as part of this, I've flipped what the toggle actually shows, with it now being "checked" when popups are enabled, which to me again feels more conventional for UI.

This also tweaks the position of the toggle on the page to match the height of the main overlay toggle, which I think provides a bit more visual consistency for the overlay.

![image](https://user-images.githubusercontent.com/12371363/213899215-681ff820-8aea-4a3b-8dae-8680c3dc2ddf.png)
![image](https://user-images.githubusercontent.com/12371363/213899221-f1dd82cf-8e9a-4e0f-b045-3a97c2001164.png)

(This also switches the checkbox itself to being a controlled React input with onChange/checked)