### PR TITLE
Use lazy initialization of settings to avoid race

### DIFF
--- a/src/pages/overlay/App.tsx
+++ b/src/pages/overlay/App.tsx
@@ -9,16 +9,17 @@ import OverlaySettings from "./components/overlaySettings/OverlaySettings"
 import styles from "./App.module.css"
 
 export default function App(){
-    const [overlaySettings, setOverlaySettings] = useState({
-        disableChatPopup: false,
+    const [overlaySettings, setOverlaySettings] = useState(() => {
+        // Load settings from local storage, merging with defaults
+        const settings = JSON.parse(localStorage.getItem("settings") || "{}")
+        return {
+            disableChatPopup: false,
+            ...settings
+        }
     })
 
     useEffect(() => {
-        //load settings from local storage
-        setOverlaySettings(JSON.parse(localStorage.getItem("settings") || "{}"))
-    }, [])
-    useEffect(() => {
-        //save settings to local storage
+        // save settings to local storage
         localStorage.setItem("settings", JSON.stringify(overlaySettings))
     }, [overlaySettings])
 


### PR DESCRIPTION
Fixes #31 which I accidentally caused in #29 with the input becoming a controlled input.

With the state as `false` by default and the setting loading via a hook, it allowed React to emit a change for it to that value in the same tick. Switching to lazy initialization of the state ensures that the initial value is whatever should be loaded from local storage.