### PR TITLE
Refactor ambassador commands to use fixed ids

### DIFF
--- a/src/assets/ambassadors.json
+++ b/src/assets/ambassadors.json
@@ -1,5 +1,6 @@
 [
     {
+        "id": "appa",
         "name": "Appa",
         "species": "Common Marmoset",
         "img": {
@@ -14,6 +15,7 @@
         "conservationMission": "He is an ambassador for the exotic pet trade and how it affects primate species worldwide."
     },
     {
+        "id": "momo",
         "name": "Momo",
         "species": "Black-tufted Marmoset",
         "img": {
@@ -28,6 +30,7 @@
         "conservationMission": "He is an ambassador for the exotic pet trade and how it affects primate species worldwide."
     },
     {
+        "id": "chips",
         "name": "Chips Ahoy",
         "species": "Domestic Rat",
         "img": {
@@ -42,6 +45,7 @@
         "conservationMission": "She is an ambassadors for how rodenticide use and outdoor cats affect all levels of wildlife."
     },
     {
+        "id": "nilla",
         "name": "Nilla Wafer",
         "species": "Domestic Rat",
         "img": {
@@ -56,6 +60,7 @@
         "conservationMission": "She is an ambassadors for how rodenticide use and outdoor cats affect all levels of wildlife."
     },
     {
+        "id": "henrietta",
         "name": "Henrietta",
         "species": "Jersey Giant",
         "img": {
@@ -70,6 +75,7 @@
         "conservationMission": "She is an ambassador for the agricultural industry and how people can use consumer choice to impact the environment in a positive way."
     },
     {
+        "id": "henrique",
         "name": "Henrique",
         "species": "Half Dark Brahma, Half Saipan",
         "img": {
@@ -84,6 +90,7 @@
         "conservationMission": "She is an ambassador for the agricultural industry and how people can use consumer choice to impact the environment in a positive way."
     },
     {
+        "id": "nugget",
         "name": "Nugget",
         "species": "Ameraucana Chicken",
         "img": {
@@ -98,6 +105,7 @@
         "conservationMission": "She is an ambassador for the agricultural industry and how people can use consumer choice to impact the environment in a positive way."
     },
     {
+        "id": "oliver",
         "name": "Oliver",
         "species": "Olive Egger Chicken",
         "img": {
@@ -112,6 +120,7 @@
         "conservationMission": "He is an ambassador for the agricultural industry and how people can use consumer choice to impact the environment in a positive way."
     },
     {
+        "id": "toaster",
         "name": "Toaster Strudel",
         "species": "Blue-tongued Skink",
         "img": {
@@ -126,6 +135,7 @@
         "conservationMission": "He is an ambassador for how human development and invasive species can affect natural habitats and native species. "
     },
     {
+        "id": "puppy",
         "name": "Puppy",
         "species": "Emperor Scorpion",
         "img": {
@@ -140,6 +150,7 @@
         "conservationMission": "He is an ambassador for the importance of invertebrates and the misconceptions they face."
     },
     {
+        "id": "tortellini",
         "name": "Tortellini",
         "species": "Emperor Scorpion",
         "img": {
@@ -154,6 +165,7 @@
         "conservationMission": "He is an ambassador for the importance of invertebrates and the misconceptions they face."
     },
     {
+        "id": "fenn",
         "name": "Fenn",
         "species": "European Red Fox",
         "img": {
@@ -168,6 +180,7 @@
         "conservationMission": "He is an ambassador for the exploitation of wildlife in the pet trade and the fur trade."
     },
     {
+        "id": "reed",
         "name": "Reed",
         "species": "European Red Fox",
         "img": {
@@ -182,6 +195,7 @@
         "conservationMission": "He is an ambassador for the exploitation of wildlife in the pet trade and the fur trade."
     },
     {
+        "id": "winnie",
         "name": "Winnie (The Moo)",
         "species": "Red Angus Beef Cow",
         "img": {
@@ -196,6 +210,7 @@
         "conservationMission": "She is an ambassador for the beef industry and how people can use their consumer choice to impact the environment in a positive way."
     },
     {
+        "id": "mia",
         "name": "Mia",
         "species": "African Grey",
         "img": {
@@ -210,6 +225,7 @@
         "conservationMission": "She is an ambassador for how the pet trade has affected her parrot species and many others around the world."
     },
     {
+        "id": "siren",
         "name": "Siren",
         "species": "Blue-frontend Amazon",
         "img": {
@@ -224,6 +240,7 @@
         "conservationMission": "She is an ambassador for how the pet trade has affected her parrot species and many others around the world."
     },
     {
+        "id": "miley",
         "name": "Miley",
         "species": "Catalina Macaw",
         "img": {
@@ -238,6 +255,7 @@
         "conservationMission": "She is an ambassador for how the pet trade has affected her parrot species and many others around the world."
     },
     {
+        "id": "tico",
         "name": "Tico",
         "species": "Blue and Gold Macaw",
         "img": {
@@ -252,6 +270,7 @@
         "conservationMission": "She is an ambassador for how the pet trade has affected her parrot species and many others around the world."
     },
     {
+        "id": "moomin",
         "name": "Moomin",
         "species": "Chinchilla",
         "img": {
@@ -266,6 +285,7 @@
         "conservationMission": "He is an ambassador for the exploitation of wildlife in the fur trade."
     },
     {
+        "id": "snork",
         "name": "Snork",
         "species": "Chinchilla",
         "img": {
@@ -280,6 +300,7 @@
         "conservationMission": "She is an ambassador for the exploitation of wildlife in the fur trade."
     },
     {
+        "id": "jalapeno",
         "name": "Jalapeño",
         "species": "Domestic Donkey",
         "img": {
@@ -294,6 +315,7 @@
         "conservationMission": "He is an ambassador for the wildlife trade and use of wild animals in traditional medicine."
     },
     {
+        "id": "serrano",
         "name": "Serrano",
         "species": "Domestic Donkey",
         "img": {
@@ -308,6 +330,7 @@
         "conservationMission": "He is an ambassador for the wildlife trade and use of wild animals in traditional medicine."
     },
     {
+        "id": "stompy",
         "name": "Stompy",
         "species": "Emu",
         "img": {
@@ -322,6 +345,7 @@
         "conservationMission": "He is an ambassador for how the exotic meat trade and the use of animal products in cosmetics has affected his species and others."
     },
     {
+        "id": "georgie",
         "name": "Georgie",
         "species": "African Bullfrog",
         "img": {
@@ -336,6 +360,7 @@
         "conservationMission": "He is an ambassador for the wildlife trade and how chytrid fungus is affecting amphibian species worldwide."
     },
     {
+        "id": "noodle",
         "name": "Noodle",
         "species": "Carpet Python",
         "img": {
@@ -350,6 +375,7 @@
         "conservationMission": "She is an ambassador for how the pet trade and habitat loss has affected hers and many other reptile species worldwide."
     },
     {
+        "id": "patchy",
         "name": "Patchy",
         "species": "Ball Python",
         "img": {
@@ -364,6 +390,7 @@
         "conservationMission": "He is an ambassador for how the pet trade and habitat loss has affected his and many other reptile species worldwide."
     },
     {
+        "id": "abbott",
         "name": "Abbott",
         "species": "American Crow",
         "img": {
@@ -378,6 +405,7 @@
         "conservationMission": "He is an ambassador for educating people on the misconceptions that wildlife face as well as human-wildlife conflict."
     },
     {
+        "id": "coconut",
         "name": "Coconut",
         "species": "American Crow",
         "img": {
@@ -392,6 +420,7 @@
         "conservationMission": "He is an ambassador for educating people on the misconceptions that wildlife face as well as human-wildlife conflict."
     },
     {
+        "id": "baked",
         "name": "Baked Bean",
         "species": "Madagascar Hissing Cockroach",
         "img":{
@@ -406,6 +435,7 @@
         "conservationMission": "They are ambassadors for the importance of invertebrates and the misconceptions they face."
     },
     {
+        "id": "barbara",
         "name": "Barbara",
         "species": "Madagascar Hissing Cockroach",
         "img":{
@@ -420,6 +450,7 @@
         "conservationMission": "They are ambassadors for the importance of invertebrates and the misconceptions they face."
     },
     {
+        "id": "bb",
         "name": "BB",
         "species": "Spanish Orange Isopods",
         "img":{
@@ -434,6 +465,7 @@
         "conservationMission": "They are ambassadors for the importance of invertebrates and the misconceptions they face."
     },
     {
+        "id": "ducky",
         "name": "Ducky",
         "species": "Rubber Ducky Isopods",
         "img": {
@@ -448,6 +480,7 @@
         "conservationMission": "They are ambassadors for the importance of invertebrates and the misconceptions they face."
     },
     {
+        "id": "marty",
         "name": "Marty",
         "species": "Zebra Isopods",
         "img": {
@@ -462,6 +495,7 @@
         "conservationMission": "They are ambassadors for the importance of invertebrates and the misconceptions they face."
     },
     {
+        "id": "hank",
         "name": "Hank (The Tank)",
         "species": "Smokey Ghost Millipede",
         "img": {
@@ -476,6 +510,7 @@
         "conservationMission": "He is an ambassador for the importance of invertebrates and the misconceptions they face."
     },
     {
+        "id": "pickles",
         "name": "Pickles",
         "species": "Vinegaroon",
         "img": {

--- a/src/pages/overlay/components/ambassadorList/AmbassadorList.tsx
+++ b/src/pages/overlay/components/ambassadorList/AmbassadorList.tsx
@@ -13,7 +13,7 @@ import arrow from '../../../../assets/arrow.jpg'
 
 export interface AmbassadorListProps{
     showAmbassadorList: boolean
-    chatChosenAmbassador?: string
+    chatChosenAmbassadorId?: string
 }
 export default function AmbassadorList(props: AmbassadorListProps){
     const [ambassadors] = useState(AmbassadorData)
@@ -24,21 +24,21 @@ export default function AmbassadorList(props: AmbassadorListProps){
     const downArrowRef = useRef<HTMLImageElement>(null)
 
     useEffect(() =>{ // show the card of the ambassador that Twitch chat chose
-        if(props.chatChosenAmbassador !== undefined){
-            const ambassador = ambassadors.find(ambassador => ambassador.name.split(" ")[0].toLowerCase() === props.chatChosenAmbassador)
+        if(props.chatChosenAmbassadorId){
+            const ambassador = ambassadors.find(ambassador => ambassador.id === props.chatChosenAmbassadorId)
             if(ambassador){
                 setActiveAmbassador(ambassador)
-                scrollListToAmbassador(ambassador.name.split(" ")[0].toLowerCase())
+                scrollListToAmbassador(ambassador.id)
             }
         }
-    }, [props.chatChosenAmbassador])
+    }, [props.chatChosenAmbassadorId])
 
     const scrollListToAmbassador = (name: string) => {
         if(!ambassadorList.current)
             return
 
         const offset = 200
-        const anchorElement = ambassadorList.current.querySelector(`#${name}`)
+        const anchorElement = ambassadorList.current.querySelector(`#ambassador-${name}`)
         if(anchorElement instanceof HTMLDivElement)
             ambassadorList.current.scrollTo({top: Math.max(0, anchorElement.offsetTop - offset), behavior: "smooth"})
     }
@@ -77,7 +77,7 @@ export default function AmbassadorList(props: AmbassadorListProps){
                             getCard={() => {setActiveAmbassador(activeAmbassador?.name === ambassador.name ? undefined : ambassador)}}
 
                             ClassName={`${styles.ambassadorButton} ${activeAmbassador?.name === ambassador.name ? styles.ambassadorButtonClicked : undefined}`}
-                            Id={ambassador.name.split(" ")[0].toLowerCase()}
+                            Id={`ambassador-${ambassador.id}`}
                         />
                     ))}
                 </div>

--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -17,11 +17,11 @@ interface OverlayProps {
 export default function Overlay(props: OverlayProps) {
     const [showAmbassadorList, setShowAmbassadorList] = useState(false)
     const [isOverlayVisible, setIsOverlayVisible] = useState(false)
-    const chosenAmbassador = useChatCommand()
+    const chosenAmbassadorId = useChatCommand()
     const timeoutRef = useRef<NodeJS.Timeout | undefined>(undefined)
 
     useEffect(() => {
-        if(chosenAmbassador !== undefined && props.settings.disableChatPopup === false){
+        if(chosenAmbassadorId && props.settings.disableChatPopup === false){
             console.log(props.settings.disableChatPopup)
             setIsOverlayVisible(true)
             setShowAmbassadorList(true)
@@ -34,7 +34,7 @@ export default function Overlay(props: OverlayProps) {
         }
         return () => clearTimeout(timeoutRef.current as NodeJS.Timeout) 
 
-    }, [chosenAmbassador])
+    }, [chosenAmbassadorId])
 
     useEffect(() => {
         initMouseEventListener()
@@ -64,7 +64,7 @@ export default function Overlay(props: OverlayProps) {
         />
         <AmbassadorList
             showAmbassadorList={showAmbassadorList}
-            chatChosenAmbassador={chosenAmbassador?.slice(1)}
+            chatChosenAmbassadorId={chosenAmbassadorId}
         />
     </div>
     )

--- a/src/pages/panel/components/ambassadorPanel/AmbassadorPanel.tsx
+++ b/src/pages/panel/components/ambassadorPanel/AmbassadorPanel.tsx
@@ -1,3 +1,5 @@
+import { useState, useEffect } from "react";
+
 //components & hooks
 import AmbassadorButton from "../../../../utils/global/ambassadorButton/AmbassadorButton";
 import AmbassadorCardOverlay from "../ambassadorCardOverlay/AmbassadorCardOverlay";
@@ -7,42 +9,34 @@ import useChatCommand from "../../../../utils/chatCommand";
 import styles from './ambassadorPanel.module.css'
 
 //data
-import { useState, useEffect } from "react";
 import AmbassadorData from "../../../../assets/ambassadors.json";
 
 
 export default function AmbassadorPanel() {
   const [ambassadors] = useState(AmbassadorData)
-  const [ambassadorCard, setAmbassadorCard] = useState("") //name of ambassador that will show up as a modal
-  const chosenAmbassador = useChatCommand()?.slice(1)
+  const [cardAmbassadorId, setCardAmbassadorId] = useState<string | undefined>(undefined) // id of ambassador that will show up as a modal
+  const chosenAmbassadorId = useChatCommand()
 
   useEffect(() => {
-    if(chosenAmbassador !== undefined){
-      setAmbassadorCard(ambassadors.find(ambassador => ambassador.name.split(" ")[0].toLowerCase() === chosenAmbassador)?.name || "")
+    if(chosenAmbassadorId){
+      setCardAmbassadorId(chosenAmbassadorId)
     }
-  }, [chosenAmbassador, ambassadors])
-
-  function handleClose(): void{
-    setAmbassadorCard("")
-  }
-  function handleGetCard(name: string): void {
-    setAmbassadorCard(name)
-  }
+  }, [chosenAmbassadorId])
 
   return (
     <main className={styles.ambassadors}> 
       {ambassadors && ambassadors.map(ambassador => (
         <>
-          {ambassadorCard === ambassador.name ? 
+          {cardAmbassadorId === ambassador.id ?
             <AmbassadorCardOverlay
               ambassadorCard={{cardData: ambassador}}
 
-              close={handleClose}
+              close={() => setCardAmbassadorId(undefined)}
             />
             : null
           }
           <AmbassadorButton
-            key={ambassador.name} // every ambassador will have a unique name
+            key={ambassador.id}
             name={ambassador.name}
             species={ambassador.species}
             img={{
@@ -50,7 +44,7 @@ export default function AmbassadorPanel() {
               altText: ambassador.img.altText
             }}
 
-            getCard={()=>handleGetCard(ambassador.name)}
+            getCard={() => setCardAmbassadorId(ambassador.id)}
           />
         </>
       ))}

--- a/src/utils/chatCommand.ts
+++ b/src/utils/chatCommand.ts
@@ -2,39 +2,9 @@ import { useEffect, useState } from 'react'
 import tmi, { ChatUserstate } from 'tmi.js'
 import AmbassadorData from '../assets/ambassadors.json'
 
-/**
- * @description Some ambassadors have names with diacritics in them (Ex: Jalapeño). 
- * Note: a diacritic is a mark added to a letter to change its sound or meaning (Ex: ñ). 
- * This function creates a map of an ambassador with diacritics in their name and their name without diacritics.
- * (Ex: { jalapeno: jalapeño })
- * @returns a map of the normalized names and original names
- */
-const getMapOfAmbassadorWithDiacritics = (): Map<string, string> => {
-    //store names that have letters with diacritics in them
-    const ambassadorsWithDiacriticsInNames = AmbassadorData.filter(
-        (ambassador) =>{ 
-            const ambassadorOriginalFirstName = ambassador.name.split(' ')[0].toLowerCase()
-            const ambassadorFirstNameWithRemovedDiacritic = ambassadorOriginalFirstName.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
-
-            return ambassadorOriginalFirstName !== ambassadorFirstNameWithRemovedDiacritic
-        }
-    )
-    // a hashmap of the normalized names and their original names
-    const diacriticMap = new Map<string, string>()
-    ambassadorsWithDiacriticsInNames.forEach((ambassador) => {
-        const ambassadorOriginalFirstName = ambassador.name.split(' ')[0].toLowerCase()
-        const ambassadorFirstNameWithRemovedDiacritic = ambassadorOriginalFirstName.normalize('NFD').replace(/[\u0300-\u036f]/g, '')
-        diacriticMap.set(ambassadorFirstNameWithRemovedDiacritic, ambassadorOriginalFirstName)
-    })
-
-    return diacriticMap
-}
-
 export default function useChatCommand() {
-    const [command, setCommand] = useState<string>()
-    const ambassadorNames = AmbassadorData.map((ambassador) => ambassador.name.split(' ')[0].toLowerCase())
-
-    const diacriticsMap: Map<string, string> = getMapOfAmbassadorWithDiacritics()
+    const [chosenAmbassadorId, setChosenAmbassadorId] = useState<string>()
+    const ambassadorIds = AmbassadorData.map((ambassador) => ambassador.id)
 
     const client = new tmi.Client({
         connection: {
@@ -60,16 +30,14 @@ export default function useChatCommand() {
         // Ignore echoed messages (messages sent by the bot) and messages that don't start with '!'
         if (self || !msg.trim().startsWith('!')) return
 
-        const commandName = msg.trim().toLowerCase() 
-        if(ambassadorNames.find((name) => name === commandName.slice(1))) {
-            setCommand(commandName)
-        }else if(diacriticsMap.get(commandName.slice(1))) { // Check if a user typed a name without diacritics (Ex: !jalapeno should be !Jalapeño)
-            setCommand("!"+diacriticsMap.get(commandName.slice(1)))
+        const ambassadorCommand = msg.trim().slice(1).toLowerCase()
+        if(ambassadorIds.find((id) => id === ambassadorCommand)) {
+            setChosenAmbassadorId(ambassadorCommand)
         }
     }
     const connectedHandler = () => {
         console.log('*Twitch extension is connected to chat*')
     }
 
-    return command
+    return chosenAmbassadorId
 }

--- a/src/utils/global/ambassadorButton/AmbassadorButton.tsx
+++ b/src/utils/global/ambassadorButton/AmbassadorButton.tsx
@@ -9,7 +9,7 @@ interface AmbassadorButtonProps{
   name: string
   species: string
 
-  getCard?: (name: string) => void
+  getCard?: () => void
   changeEditMode?: () => void
 
   ClassName?: string
@@ -18,7 +18,7 @@ interface AmbassadorButtonProps{
 export default function AmbassadorButton(props: AmbassadorButtonProps) {
   function handleClick(): void {
     if(props.getCard)
-      props.getCard(props.name)
+      props.getCard()
 
     if(props.changeEditMode)
       props.changeEditMode()


### PR DESCRIPTION
I do not known how important supporting the `!Jalapeño` command is, if not so much, i would propose this change: 
Instead of splitting and normalizing the name this defines the IDs in the `ambassadors.json` for each ambassador which makes it easier to work with the data. Is necessary you could also add some optional aliases here, if we need to support multiple spellings of one ambassador.

NOTE: this removes the option to use both names with and without diacritics in the commands (which is currently only !jalapeno).