### PR TITLE
Allow same command repeatedly, use callback instead of return

### DIFF
--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -38,18 +38,16 @@ export default function Overlay(props: OverlayProps) {
   // When a chat command is run, wake the overlay
   useChatCommand(useCallback((command: string) => {
     if (!settings.disableChatPopup) {
-      if (command === '!welcome') {
-        dispatch({type: ACTIONS.SHOW_ALVEUS_INTRO})
-        return;
-      }
+      if (command !== '!welcome') setChosenAmbassador(command.slice(1))
 
-      // Show the list
-      setChosenAmbassador(command.slice(1))
-      dispatch({type: ACTIONS.SHOW_AMBASSADOR_LIST})
+      // Show the card
+      dispatch({type: command === '!welcome' ? ACTIONS.SHOW_ALVEUS_INTRO : ACTIONS.SHOW_AMBASSADOR_LIST})
 
       // Dismiss the overlay after a delay
       if (timeoutRef.current) clearTimeout(timeoutRef.current)
-      timeoutRef.current = setTimeout(() => { dispatch({type: ACTIONS.HIDE_AMBASSADOR_LIST}) }, commandDelay)
+      timeoutRef.current = setTimeout(() => {
+        dispatch({type: command === '!welcome' ? ACTIONS.HIDE_ALVEUS_INTRO : ACTIONS.HIDE_AMBASSADOR_LIST})
+      }, commandDelay)
 
       // Track that we're waking up, so that we don't immediately clear the timeout, and wake the overlay
       awakingRef.current = true

--- a/src/pages/panel/components/ambassadorPanel/AmbassadorPanel.tsx
+++ b/src/pages/panel/components/ambassadorPanel/AmbassadorPanel.tsx
@@ -7,14 +7,18 @@ import useChatCommand from "../../../../utils/chatCommand";
 import styles from './ambassadorPanel.module.css'
 
 //data
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react"
 import AmbassadorData from "../../../../assets/ambassadors.json";
 
 
 export default function AmbassadorPanel() {
   const [ambassadors] = useState(AmbassadorData)
   const [ambassadorCard, setAmbassadorCard] = useState("") //name of ambassador that will show up as a modal
-  const chosenAmbassador = useChatCommand()?.slice(1)
+
+  const [chosenAmbassador, setChosenAmbassador] = useState<string | undefined>(undefined)
+  useChatCommand(useCallback((command: string) => {
+    setChosenAmbassador(command.slice(1))
+  }, []))
 
   useEffect(() => {
     if (chosenAmbassador !== undefined)


### PR DESCRIPTION
Resolves #50

Running the same command multiple times will re-awaken the overlay to show the same ambassador again. This switches the chat hook from returning the last ambassador to calling a provided callback when a new ambassador command is run.