### PR TITLE
Fix sleeping styling

### DIFF
--- a/src/pages/overlay/App.module.scss
+++ b/src/pages/overlay/App.module.scss
@@ -5,4 +5,17 @@
   bottom: 40px;
   left: 15px;
   right: 15px;
+  transition: opacity 0.3s ease-out;
+}
+
+.visible {
+  opacity: 1;
+}
+
+.hidden {
+  opacity: 0;
+
+  * {
+    pointer-events: none;
+  }
 }

--- a/src/pages/overlay/components/overlay/overlay.module.scss
+++ b/src/pages/overlay/components/overlay/overlay.module.scss
@@ -4,21 +4,17 @@
   display: flex;
   height: 100%;
   width: 100%;
-
-  // horizontal spacing (scaled dynamically based on available height)
-  gap: $overlay-base-size;
-
-  transition: all 0.3s ease-out;
+  gap: $overlay-base-size; // horizontal spacing (scaled dynamically based on available height)
+  transition: 0.3s ease-out;
+  transition-property: visibility, translate;
 }
 
 .visible {
   visibility: visible;
-  opacity: 1;
 }
 
 .hidden {
   visibility: hidden;
-  opacity: 0;
   translate: -40px;
 
   // accessibility for vestibular motion disorders

--- a/src/pages/overlay/components/overlaySettings/overlaySettings.module.scss
+++ b/src/pages/overlay/components/overlaySettings/overlaySettings.module.scss
@@ -15,11 +15,10 @@
 .hidden {
   visibility: hidden;
   translate: 40px;
-}
 
-@media (prefers-reduced-motion) {
-  // just rely on app fade
-  .hidden {
+  // accessibility for vestibular motion disorders
+  // do not translate overlay but only transition opacity
+  @media (prefers-reduced-motion) {
     translate: 0;
   }
 }


### PR DESCRIPTION
Noticed a few issues with how the app was sleeping now (settings weren't fading, elements still showed cursors). I think this might've broken with the intro stuff being pushed.

This fades the opacity at the app level, and disables pointer events for everything within the app while sleeping. The user can still interact with the app (mouse movements) to wake again.

Each component can then do anything extra when sleeping, like sliding out of frame.