### PR TITLE
Close overlay panels on click in body

### DIFF
--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -72,8 +72,26 @@ export default function Overlay(props: OverlayProps) {
     return () => awoken.remove(callback)
   }, [awoken])
 
-    return (
-    <div className={`${styles.overlay} ${sleeping ? styles.hidden : styles.visible}`} >
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const bodyClick = useCallback((e: MouseEvent) => {
+    // If the click was inside the overlay parent, and wasn't the overlay itself, ignore it
+    // Check the parent so that clicking on the settings doesn't close the panels
+    if (!overlayRef.current
+      || (overlayRef.current !== e.target && (overlayRef.current.parentElement as Node).contains(e.target as Node))) return
+
+    // Otherwise, close the panels
+    dispatch({type: ACTIONS.HIDE_AMBASSADOR_LIST})
+    dispatch({type: ACTIONS.HIDE_ALVEUS_INTRO})
+  }, []);
+
+  // If the user clicks anywhere in the body, except the overlay itself, close the panels
+  useEffect(() => {
+    document.body.addEventListener('click', bodyClick);
+    return () => document.body.removeEventListener('click', bodyClick);
+  }, [bodyClick]);
+
+  return (
+    <div ref={overlayRef} className={`${styles.overlay} ${sleeping ? styles.hidden : styles.visible}`}>
       <ActivationButtons
         toggleShowAmbassadorList={() => dispatch({type: showAmbassadorList ? ACTIONS.HIDE_AMBASSADOR_LIST : ACTIONS.SHOW_AMBASSADOR_LIST})}
         toggleShowAlveusIntro={() => dispatch({type: showAlveusIntro ? ACTIONS.HIDE_ALVEUS_INTRO : ACTIONS.SHOW_ALVEUS_INTRO})}

--- a/src/pages/overlay/components/overlay/Overlay.tsx
+++ b/src/pages/overlay/components/overlay/Overlay.tsx
@@ -72,26 +72,34 @@ export default function Overlay(props: OverlayProps) {
     return () => awoken.remove(callback)
   }, [awoken])
 
-  const overlayRef = useRef<HTMLDivElement>(null);
   const bodyClick = useCallback((e: MouseEvent) => {
-    // If the click was inside the overlay parent, and wasn't the overlay itself, ignore it
-    // Check the parent so that clicking on the settings doesn't close the panels
-    if (!overlayRef.current
-      || (overlayRef.current !== e.target && (overlayRef.current.parentElement as Node).contains(e.target as Node))) return
+    // Get all the elements under the mouse
+    const elements = document.elementsFromPoint(e.clientX, e.clientY);
 
-    // Otherwise, close the panels
+    // For each element, if it has a background then we want to ignore the click
+    // If we reach the body, then break out of the loop and close the panels
+    for (const element of elements) {
+      if (element === document.body) break;
+
+      const style = getComputedStyle(element);
+      if (style.backgroundImage !== 'none' || style.backgroundColor !== 'rgba(0, 0, 0, 0)') {
+        return;
+      }
+    }
+
     dispatch({type: ACTIONS.HIDE_AMBASSADOR_LIST})
     dispatch({type: ACTIONS.HIDE_ALVEUS_INTRO})
   }, []);
 
   // If the user clicks anywhere in the body, except the overlay itself, close the panels
+  // Bind it during the capture phase so that we can process it before any other click handlers
   useEffect(() => {
-    document.body.addEventListener('click', bodyClick);
-    return () => document.body.removeEventListener('click', bodyClick);
+    document.body.addEventListener('click', bodyClick, true);
+    return () => document.body.removeEventListener('click', bodyClick, true);
   }, [bodyClick]);
 
   return (
-    <div ref={overlayRef} className={`${styles.overlay} ${sleeping ? styles.hidden : styles.visible}`}>
+    <div className={`${styles.overlay} ${sleeping ? styles.hidden : styles.visible}`}>
       <ActivationButtons
         toggleShowAmbassadorList={() => dispatch({type: showAmbassadorList ? ACTIONS.HIDE_AMBASSADOR_LIST : ACTIONS.SHOW_AMBASSADOR_LIST})}
         toggleShowAlveusIntro={() => dispatch({type: showAlveusIntro ? ACTIONS.HIDE_ALVEUS_INTRO : ACTIONS.SHOW_ALVEUS_INTRO})}


### PR DESCRIPTION
Resolves #61.

This is slightly hacky, in that it relies on checking the parent of the overlay itself, so that click on setting doesn't close the panels. It should work as desired though.